### PR TITLE
commenting out superfluous INCREF that causes memory leak

### DIFF
--- a/dotstar.c
+++ b/dotstar.c
@@ -529,7 +529,7 @@ static PyObject *Color(DotStarObject *self, PyObject *arg) {
 	if(!PyArg_ParseTuple(arg, "bbb", &r, &g, &b)) return NULL;
 
 	result = Py_BuildValue("I", (r << 16) | (g << 8) | b);
-	Py_INCREF(result);
+	//Py_INCREF(result);
 	return result;
 }
 


### PR DESCRIPTION
The problem is the Py_INCREF(), it increases the reference count of result from 1 to 2.  Then you return it to Python.  The problem is that when result (the or whatever Python variable is named) is garbage collected, this decrements the refcount by 1 so refcount is not == 0 so the variable is not removed.  Every time you call this routine you get 4 (or 8) bytes of memory allocated and not released.

This pull request fixes the issue documented here: https://github.com/adafruit/Adafruit_DotStar_Pi/issues/15