### PR TITLE
Updated setup.py to link with bcm_host.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,9 @@
 from distutils.core import setup, Extension
-setup(name='dotstar', version='0.2', ext_modules=[Extension('dotstar', ['dotstar.c'], include_dirs=['/opt/vc/include'])])
+
+setup(name='dotstar',
+      version='0.2',
+      ext_modules=[Extension('dotstar',
+                             ['dotstar.c'],
+                             include_dirs=['/opt/vc/include'],
+                             library_dirs=['/opt/vc/lib'],
+                             libraries=['bcm_host'])])


### PR DESCRIPTION
The dotstar.so file produced by setup.py failed to load because it didn't link with bcm_host.